### PR TITLE
Repositioning the $platform parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ try {
     $identifyResponse = $mantleClient->identify(
         $platformId = 'customer_platform_id',
         $myshopifyDomain = 'customer_shop.myshopify.com',
-        $platform = 'shopify',
         $accessToken = 'platform_access_token',
         $name = 'Customer Name',
-        $email = 'customer@example.com'
+        $email = 'customer@example.com',
+        $platform = 'shopify'
     );
     echo "Customer identified; API Token: " . $identifyResponse['apiToken'] . PHP_EOL;
 

--- a/mantle-client.php
+++ b/mantle-client.php
@@ -64,7 +64,7 @@ class MantleClient {
         return json_decode($response, true);
     }
 
-    public function identify($platformId, $myshopifyDomain, $platform = 'shopify', $accessToken, $name, $email, $customFields = null) {
+    public function identify($platformId, $myshopifyDomain, $accessToken, $name, $email, $customFields = null, $platform = 'shopify') {
         $body = [
             'platformId' => $platformId,
             'myshopifyDomain' => $myshopifyDomain,


### PR DESCRIPTION
I'm repositioning it to the last position since it's not required due to the default `shopify` parameter.